### PR TITLE
Updated Realtime Javascript library CDN link

### DIFF
--- a/client/src/public/battery-usage.html
+++ b/client/src/public/battery-usage.html
@@ -40,7 +40,7 @@
 
     <script src="http://cdn.pubnub.com/pubnub.min.js"></script>
     <script src="http://js.pusher.com/2.1/pusher.min.js"></script>
-    <script src="http://dfdbz2tdq3k01.cloudfront.net/js/2.1.0/ortc.js"></script>
+    <script src="http://messaging-public.realtime.co/js/2.1.0/ortc.js"></script>
     <script src="https://cdn.firebase.com/js/client/1.0.17/firebase.js"></script>
     <script src="http://cdn.hydna.com/1/hydna.js"></script>
     <script src="js/service-libs/fanout.js"></script>

--- a/client/src/public/index.html
+++ b/client/src/public/index.html
@@ -7,7 +7,7 @@
 
         <script src="http://cdn.pubnub.com/pubnub.min.js"></script>
         <script src="http://js.pusher.com/2.1/pusher.min.js"></script>
-        <script src="http://dfdbz2tdq3k01.cloudfront.net/js/2.1.0/ortc.js"></script>
+        <script src="http://messaging-public.realtime.co/js/2.1.0/ortc.js"></script>
         <script src="https://cdn.firebase.com/js/client/1.0.17/firebase.js"></script>
         <script src="http://cdn.hydna.com/1/hydna.js"></script>
         <script src="js/service-libs/fanout.js"></script>

--- a/server/benchmark.js
+++ b/server/benchmark.js
@@ -2,7 +2,7 @@
 
 	head.js('http://cdn.pubnub.com/pubnub.min.js',
 				'http://js.pusher.com/2.1/pusher.min.js',
-				'http://dfdbz2tdq3k01.cloudfront.net/js/2.1.0/ortc.js',
+				'http://messaging-public.realtime.co/js/2.1.0/ortc.js',
 				'https://cdn.firebase.com/js/client/1.0.17/firebase.js',
 				'http://cdn.hydna.com/1/hydna.js',
 				'http://pubsub.fanout.io/static/json2.js',

--- a/server/test.php
+++ b/server/test.php
@@ -7,7 +7,7 @@
 
         <script src="https://cdn.pubnub.com/pubnub.min.js"></script>
         <script src="http://js.pusher.com/2.1/pusher.min.js"></script>
-        <script src="http://dfdbz2tdq3k01.cloudfront.net/js/2.1.0/ortc.js"></script>
+        <script src="http://messaging-public.realtime.co/js/2.1.0/ortc.js"></script>
         <script src="https://cdn.firebase.com/v0/firebase.js"></script>
         <script src="http://cdn.hydna.com/1/hydna.js"></script>
         <script src="http://pubsub.fanout.io/static/json2.js"></script>


### PR DESCRIPTION
The cloudfront url is deprecated, update it to the new url
